### PR TITLE
chore: init codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# See 
+* https://help.github.com/articles/about-codeowners/
+* https://dev.to/eunice-js/a-comprehensive-guide-to-codeowners-in-github-22ga
+
+# Global owners
+*   @rac/engineering


### PR DESCRIPTION
## What does this change?
Init CODEOWNERS

## Background / Why?
To auto assign and marking specific domain or project to specific role / user  which has been responsbility.
